### PR TITLE
Fix showing wrong classroom until the right one has been loaded from the backend

### DIFF
--- a/frontend/src/stores/CatalogStore.ts
+++ b/frontend/src/stores/CatalogStore.ts
@@ -141,6 +141,9 @@ export const useCatalogStore = defineStore('catalog', () => {
   }
 
   async function getClassroom(id: number) {
+    if(classroom.value?.id !== id) {
+      classroom.value = undefined
+    }
     const response = await makeAPIRequest(`/catalog/classrooms/${id}`, 'GET', true, true)
     classroom.value = response.data
     return classroom.value

--- a/frontend/src/stores/EnrollmentStore.ts
+++ b/frontend/src/stores/EnrollmentStore.ts
@@ -116,6 +116,9 @@ export const useEnrollmentStore = defineStore('invitation', () => {
   }
 
   async function getEnrollment(enrollmentId: number) {
+    if(enrollment.value?.id !== enrollmentId) {
+      enrollment.value = undefined
+    }
     const response = await makeAPIRequest(`/enrollments/${enrollmentId}`, 'GET', true, true)
     enrollment.value = response.data as EnrollmentDetail
     return enrollment.value


### PR DESCRIPTION
closes #78 